### PR TITLE
Moves github API calls to server-side, adds routes for retrieving repo list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 node_modules
-public/config.json
+config.json
+
+# vim
+*.swp

--- a/README.md
+++ b/README.md
@@ -2,7 +2,12 @@
 Shows open pull requests from multiple Github repositories.
 
 # Configuration
-First create a Github access token for this application at https://github.com/settings/tokens/new. Check `repo` scope if you want to access private repositories' pull requests.  Then create a new JSON file to `./public/config.json` and fill in the access token and repositories you want to see pull requests from.
+First create a Github access token for this application at
+https://github.com/settings/tokens/new. Check `repo` scope if you want to
+access private repositories' pull requests.  Then create a new JSON file to
+`./config.json` and fill in the access token and repositories you want
+to see pull requests from.
+
 Example config file:
 ```
 {

--- a/package.json
+++ b/package.json
@@ -11,11 +11,12 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [
-    "radiator", "pull request"
+    "radiator",
+    "pull request"
   ],
   "author": "Jaakko Juutila",
   "license": "MIT",
   "dependencies": {
-    "node-static": "0.7.6"
+    "express": "4.13.4",
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,6 @@
   "author": "Jaakko Juutila",
   "license": "MIT",
   "dependencies": {
-    "express": "4.13.4",
+    "express": "4.13.4"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,13 +1,76 @@
-var static = require('node-static');
-var http = require('http');
+var express = require('express')
+var https = require('https');
+var path = require('path');
+var fs = require('fs');
 
-var PORT = 8080;
-var fileServer = new static.Server('./public');
+var PORT = 8888;
 
-http.createServer(function (request, response) {
-  request.addListener('end', function () {
-    fileServer.serve(request, response);
-  }).resume();
-}).listen(PORT);
+var app = express();
 
-console.log('pradiator server started at http://localhost:' + PORT + '/');
+// serve static files from the "public" dir
+app.use(express.static('public'));
+
+// read in the config file
+var config = JSON.parse(fs.readFileSync(path.resolve('./config.json'), 'utf-8'));
+
+if ((!config.accessToken) || (config.accessToken === '')) {
+    throw new Error("No 'accessToken' supplied in config.json!");
+}
+
+// gets the configured list of repositories
+//
+// Example: GET /repositories =>
+//   [ "foo/bar", "hello/world"]
+app.get('/repositories', function(req, res) {
+    res.status(200).json(config.repositories);
+});
+
+// Retrieves open pull request data from the github API and proxy the github response back to
+// the caller.
+//
+// Example: GET /prs/HBOCodeLabs/Hurley-Bespin =>
+//    [
+//      { url: "...", id: "...", ...},
+//      ...
+//    ]
+app.get('/prs/:owner/:repo', function(req, res) {
+
+    var repository = [req.params.owner, req.params.repo].join('/');
+
+    var opts = {
+        host: 'api.github.com',
+        method: 'GET',
+        path: '/repos/' + repository + '/pulls',
+        headers: {
+            'Authorization': 'token ' +  config.accessToken,
+            'User-Agent': 'Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)',
+            'Accept': 'application/vnd.github.v3+json'
+        }
+    }
+
+    function cb(response) {
+        var str = '';
+
+        response.on('data', function(chunk) { str += chunk; });
+
+        response.on('error', function(e) {
+            res.sendStatus(500);
+        });
+        response.on('end', function() {
+            try {
+                // parse the data, then turn around and
+                // send it back in the response
+                res.status(200).json(JSON.parse(str));
+            } catch(e) {
+                console.sendStatus(500);
+            }
+        });
+    }
+
+    https.request(opts, cb).end();
+});
+
+app.listen(PORT, function() {
+    console.log('pradiator server started at http://localhost:' + PORT + '/');
+});
+

--- a/server.js
+++ b/server.js
@@ -11,7 +11,7 @@ var app = express();
 app.use(express.static('public'));
 
 // read in the config file
-var config = JSON.parse(fs.readFileSync(path.resolve('./config.json'), 'utf-8'));
+var config = require('./config.json');
 
 if ((!config.accessToken) || (config.accessToken === '')) {
     throw new Error("No 'accessToken' supplied in config.json!");


### PR DESCRIPTION
Overview of changes:
- The config file is now located in the root dir (rather than being served as a static file)
- The config file is read on startup, and an error is thrown if no accessToken exists
- 2 new rout es have been added to the server:
  - `/repositories`, to allow client-side code to get the list of repos
  - `/prs`, to allow client-side code to get open PR data w/o having access to the github access token

This way, the config is read on the server side, and not needed by the client-side code.
